### PR TITLE
Convert CI-CD-Job to GitHub Actions

### DIFF
--- a/.github/workflows/ci-cd-job.yml
+++ b/.github/workflows/ci-cd-job.yml
@@ -10,3 +10,6 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v3.4.0
+    - name: run command
+      shell: bash
+      run: echo Rupesh 1


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://44.204.228.176:8080/job/CI-CD-Job/) :tada: